### PR TITLE
make log_analytics_workspace_id optional

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,7 @@ locals {
   default = {
     container_app_environment = {
       name                           = ""
+      log_analytics_workspace_id     = null
       infrastructure_subnet_id       = null
       internal_load_balancer_enabled = null
       tags                           = {}

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = ">=3.57.0"
+      version = ">=3.69.0"
     }
   }
   required_version = ">=1.3"


### PR DESCRIPTION
In version 3.69.0 of azurerm log_analytics_workspace_id is now optional.
https://github.com/hashicorp/terraform-provider-azurerm/pull/22733