### PR TITLE
feat:upgrade-azurerm-provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,16 @@ resource "azurerm_container_app_environment" "container_app_environment" {
   zone_redundancy_enabled                     = local.container_app_environment[each.key].zone_redundancy_enabled
   log_analytics_workspace_id                  = local.container_app_environment[each.key].log_analytics_workspace_id
   tags                                        = local.container_app_environment[each.key].tags
+
+  dynamic "workload_profile" {
+    for_each = var.workload_profiles
+    content {
+      name                  = workload_profile.value.name
+      workload_profile_type = workload_profile.value.workload_profile_type
+      minimum_count         = workload_profile.value.minimum_count
+      maximum_count         = workload_profile.value.maximum_count
+    }
+  }
 }
 
 resource "azurerm_container_app_environment_storage" "container_app_environment_storage" {

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "azurerm_container_app_environment" "container_app_environment" {
 
   
   dynamic "workload_profile" {
-    for_each =  local.container_app_environment[each.key].workload_profile == null ? [] : [0]
+    for_each =  local.container_app_environment[each.key].workload_profile.name == "" ? [] : [1]
     content { 
       name                  = local.container_app_environment[each.key].workload_profile.name
       workload_profile_type = local.container_app_environment[each.key].workload_profile.workload_profile_type

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,6 @@ resource "azurerm_container_app_environment" "container_app_environment" {
   infrastructure_subnet_id                    = local.container_app_environment[each.key].infrastructure_subnet_id
   internal_load_balancer_enabled              = local.container_app_environment[each.key].internal_load_balancer_enabled
   zone_redundancy_enabled                     = local.container_app_environment[each.key].zone_redundancy_enabled
-  public_network_access                       = local.container_app_environment[each.key].public_network_access
   log_analytics_workspace_id                  = local.container_app_environment[each.key].log_analytics_workspace_id
   tags                                        = local.container_app_environment[each.key].tags
 

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "azurerm_container_app_environment" "container_app_environment" {
   location                                    = local.container_app_environment[each.key].location
   dapr_application_insights_connection_string = local.container_app_environment[each.key].dapr_application_insights_connection_string
   infrastructure_subnet_id                    = local.container_app_environment[each.key].infrastructure_subnet_id
-  internal_load_balancer_enabled              = local.container_app_environment[each.key].internal_load_balancer_enabled
+#  internal_load_balancer_enabled              = local.container_app_environment[each.key].internal_load_balancer_enabled
   zone_redundancy_enabled                     = local.container_app_environment[each.key].zone_redundancy_enabled
   log_analytics_workspace_id                  = local.container_app_environment[each.key].log_analytics_workspace_id
   tags                                        = local.container_app_environment[each.key].tags

--- a/main.tf
+++ b/main.tf
@@ -20,12 +20,12 @@ resource "azurerm_container_app_environment" "container_app_environment" {
   tags                                        = local.container_app_environment[each.key].tags
 
   dynamic "workload_profile" {
-    for_each = var.workload_profiles
-    content {
-      name                  = workload_profile.value.name
-      workload_profile_type = workload_profile.value.workload_profile_type
-      minimum_count         = workload_profile.value.minimum_count
-      maximum_count         = workload_profile.value.maximum_count
+    for_each =  local.container_app_environment[each.key].workload_profile == null ? [] : [0]
+    content { 
+      name                  = local.container_app_environment[each.key].workload_profile.name
+      workload_profile_type = local.container_app_environment[each.key].workload_profile.workload_profile_type
+      minimum_count         = local.container_app_environment[each.key].workload_profile.minimum_count
+      maximum_count         = local.container_app_environment[each.key].workload_profile.maximum_count
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ resource "azurerm_container_app_environment" "container_app_environment" {
   for_each = var.container_app_environment
 
   name                                        = local.container_app_environment[each.key].name == "" ? each.key : local.container_app_environment[each.key].name
+  id                                          = local.container_app_environment[each.key].id
   resource_group_name                         = local.container_app_environment[each.key].resource_group_name
   location                                    = local.container_app_environment[each.key].location
   dapr_application_insights_connection_string = local.container_app_environment[each.key].dapr_application_insights_connection_string

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,8 @@ resource "azurerm_container_app_environment" "container_app_environment" {
   zone_redundancy_enabled                     = local.container_app_environment[each.key].zone_redundancy_enabled
   log_analytics_workspace_id                  = local.container_app_environment[each.key].log_analytics_workspace_id
   tags                                        = local.container_app_environment[each.key].tags
-
+  public_network_access = "Enabled"
+  
   dynamic "workload_profile" {
     for_each =  local.container_app_environment[each.key].workload_profile == null ? [] : [0]
     content { 

--- a/main.tf
+++ b/main.tf
@@ -14,21 +14,21 @@ resource "azurerm_container_app_environment" "container_app_environment" {
   location                                    = local.container_app_environment[each.key].location
   dapr_application_insights_connection_string = local.container_app_environment[each.key].dapr_application_insights_connection_string
   infrastructure_subnet_id                    = local.container_app_environment[each.key].infrastructure_subnet_id
-#  internal_load_balancer_enabled              = local.container_app_environment[each.key].internal_load_balancer_enabled
+  internal_load_balancer_enabled              = local.container_app_environment[each.key].internal_load_balancer_enabled
   zone_redundancy_enabled                     = local.container_app_environment[each.key].zone_redundancy_enabled
   log_analytics_workspace_id                  = local.container_app_environment[each.key].log_analytics_workspace_id
   tags                                        = local.container_app_environment[each.key].tags
 
   
-#  dynamic "workload_profile" {
-#    for_each =  local.container_app_environment[each.key].workload_profile == null ? [] : [0]
-#    content { 
-#      name                  = local.container_app_environment[each.key].workload_profile.name
-#      workload_profile_type = local.container_app_environment[each.key].workload_profile.workload_profile_type
-#      minimum_count         = local.container_app_environment[each.key].workload_profile.minimum_count
-#      maximum_count         = local.container_app_environment[each.key].workload_profile.maximum_count
-#    }
-#  }
+  dynamic "workload_profile" {
+    for_each =  local.container_app_environment[each.key].workload_profile == null ? [] : [0]
+    content { 
+      name                  = local.container_app_environment[each.key].workload_profile.name
+      workload_profile_type = local.container_app_environment[each.key].workload_profile.workload_profile_type
+      minimum_count         = local.container_app_environment[each.key].workload_profile.minimum_count
+      maximum_count         = local.container_app_environment[each.key].workload_profile.maximum_count
+    }
+  }
 }
 
 resource "azurerm_container_app_environment_storage" "container_app_environment_storage" {

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,6 @@ resource "azurerm_container_app_environment" "container_app_environment" {
   for_each = var.container_app_environment
 
   name                                        = local.container_app_environment[each.key].name == "" ? each.key : local.container_app_environment[each.key].name
-  id                                          = local.container_app_environment[each.key].id
   resource_group_name                         = local.container_app_environment[each.key].resource_group_name
   location                                    = local.container_app_environment[each.key].location
   dapr_application_insights_connection_string = local.container_app_environment[each.key].dapr_application_insights_connection_string

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "azurerm_container_app_environment" "container_app_environment" {
   zone_redundancy_enabled                     = local.container_app_environment[each.key].zone_redundancy_enabled
   log_analytics_workspace_id                  = local.container_app_environment[each.key].log_analytics_workspace_id
   tags                                        = local.container_app_environment[each.key].tags
-  public_network_access = "Enabled"
+
   
   dynamic "workload_profile" {
     for_each =  local.container_app_environment[each.key].workload_profile == null ? [] : [0]

--- a/main.tf
+++ b/main.tf
@@ -20,15 +20,15 @@ resource "azurerm_container_app_environment" "container_app_environment" {
   tags                                        = local.container_app_environment[each.key].tags
 
   
-  dynamic "workload_profile" {
-    for_each =  local.container_app_environment[each.key].workload_profile == null ? [] : [0]
-    content { 
-      name                  = local.container_app_environment[each.key].workload_profile.name
-      workload_profile_type = local.container_app_environment[each.key].workload_profile.workload_profile_type
-      minimum_count         = local.container_app_environment[each.key].workload_profile.minimum_count
-      maximum_count         = local.container_app_environment[each.key].workload_profile.maximum_count
-    }
-  }
+#  dynamic "workload_profile" {
+#    for_each =  local.container_app_environment[each.key].workload_profile == null ? [] : [0]
+#    content { 
+#      name                  = local.container_app_environment[each.key].workload_profile.name
+#      workload_profile_type = local.container_app_environment[each.key].workload_profile.workload_profile_type
+#      minimum_count         = local.container_app_environment[each.key].workload_profile.minimum_count
+#      maximum_count         = local.container_app_environment[each.key].workload_profile.maximum_count
+#    }
+#  }
 }
 
 resource "azurerm_container_app_environment_storage" "container_app_environment_storage" {

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ resource "azurerm_container_app_environment" "container_app_environment" {
   infrastructure_subnet_id                    = local.container_app_environment[each.key].infrastructure_subnet_id
   internal_load_balancer_enabled              = local.container_app_environment[each.key].internal_load_balancer_enabled
   zone_redundancy_enabled                     = local.container_app_environment[each.key].zone_redundancy_enabled
+  public_network_access                       = local.container_app_environment[each.key].public_network_access
   log_analytics_workspace_id                  = local.container_app_environment[each.key].log_analytics_workspace_id
   tags                                        = local.container_app_environment[each.key].tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,7 @@ locals {
     // resource definition
     container_app_environment = {
       name                                        = ""
+      id                                          = null
       dapr_application_insights_connection_string = null
       infrastructure_subnet_id                    = null
       internal_load_balancer_enabled              = null

--- a/variables.tf
+++ b/variables.tf
@@ -18,16 +18,16 @@ locals {
       id                                          = null
       dapr_application_insights_connection_string = null
       infrastructure_subnet_id                    = null
-#      internal_load_balancer_enabled              = null
+      internal_load_balancer_enabled              = null
       zone_redundancy_enabled                     = null
       log_analytics_workspace_id                  = null
       tags                                        = {}
-#      workload_profile = {
-#        name       = ""
-#        workload_profile_type  = null
-#        minimum_count = null
-#        maximum_count = null
-#      }
+      workload_profile = {
+        name       = ""
+        workload_profile_type  = null
+        minimum_count = null
+        maximum_count = null
+      }
     }
     container_app_environment_storage = {
       name        = ""

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,6 @@ locals {
       id                                          = null
       dapr_application_insights_connection_string = null
       infrastructure_subnet_id                    = null
-      public_network_access                       = null
       internal_load_balancer_enabled              = null
       zone_redundancy_enabled                     = null
       log_analytics_workspace_id                  = null

--- a/variables.tf
+++ b/variables.tf
@@ -18,16 +18,16 @@ locals {
       id                                          = null
       dapr_application_insights_connection_string = null
       infrastructure_subnet_id                    = null
-      internal_load_balancer_enabled              = null
+#      internal_load_balancer_enabled              = null
       zone_redundancy_enabled                     = null
       log_analytics_workspace_id                  = null
       tags                                        = {}
-      workload_profile = {
-        name       = ""
-        workload_profile_type  = null
-        minimum_count = null
-        maximum_count = null
-      }
+#      workload_profile = {
+#        name       = ""
+#        workload_profile_type  = null
+#        minimum_count = null
+#        maximum_count = null
+#      }
     }
     container_app_environment_storage = {
       name        = ""

--- a/variables.tf
+++ b/variables.tf
@@ -9,15 +9,6 @@ variable "container_app_environment_storage" {
   description = "Resource definition, default settings are defined within locals and merged with var settings. For more information look at [Outputs](#Outputs)."
 }
 
-variable "workload_profiles" {
-  type    = list(object({
-    name                  = string
-    workload_profile_type = string
-    minimum_count         = number
-    maximum_count         = number
-  }))
-  default = []
-}
 
 locals {
   default = {
@@ -30,6 +21,12 @@ locals {
       zone_redundancy_enabled                     = null
       log_analytics_workspace_id                  = null
       tags                                        = {}
+      workload_profile = {
+        name       = ""
+        workload_profile_type  = null
+        minimum_count = null
+        maximum_count = null
+      }
     }
     container_app_environment_storage = {
       name        = ""

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,16 @@ variable "container_app_environment_storage" {
   description = "Resource definition, default settings are defined within locals and merged with var settings. For more information look at [Outputs](#Outputs)."
 }
 
+variable "workload_profiles" {
+  type    = list(object({
+    name                  = string
+    workload_profile_type = string
+    minimum_count         = number
+    maximum_count         = number
+  }))
+  default = []
+}
+
 locals {
   default = {
     // resource definition

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,7 @@ locals {
       id                                          = null
       dapr_application_insights_connection_string = null
       infrastructure_subnet_id                    = null
+      public_network_access                       = null
       internal_load_balancer_enabled              = null
       zone_redundancy_enabled                     = null
       log_analytics_workspace_id                  = null

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = ">=3.69.0, <4.0"
+      version = ">=4.40.0, <5.0"
     }
   }
   required_version = ">=1.5"


### PR DESCRIPTION
### Description
### Upgrade azurerm provider to v4.x
Migrating from **azurerm 3.x** to **v4.x**.

**Refs**

* 4.0 Upgrade Guide: https://cf-registry.tf-registry-prod-use1.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#azure-provider-version-v40

 #### Provider constraint
 ```
 terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
       version = ">=4.40.0, <5.0"
     }
   }
   required_version = ">=1.5"
 }
 ```

### Additional information
_No response_


